### PR TITLE
Add link to cert-manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,4 @@ If you want to start building an Operator, you should definitely look into the [
 | Spark | [GoogleCloudPlatform/spark-on-k8s-operator](https://github.com/GoogleCloudPlatform/spark-on-k8s-operator) | Kubernetes CRD operator for specifying and running Apache Spark applications idiomatically on Kubernetes. |
 | Vault | [coreos/vault-operator](https://github.com/coreos/vault-operator) | Run and manage Vault on Kubernetes simply and securely. |
 | Kanister | [kanisterio/kanister](https://github.com/kanisterio/kanister) | An extensible framework for application-level data management on Kubernetes. |
+| cert-manager | [jetstack/cert-manager](https://github.com/jetstack/cert-manager) | Automatically provision and manage TLS certificates in Kubernetes |


### PR DESCRIPTION
Hey - just spotted this repo!

This PR is just adding cert-manager, our certificate management operator, to the README.

It includes support for Let's Encrypt, standard CAs (i.e. a signing keypair), and (very soon!) Hashicorp Vault.

/cc @philips 