### PR TITLE
add unifiedpush

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,4 @@ If you want to start building an Operator, you should definitely look into the [
 | Envoy | [solo-io/envoy-operator](https://github.com/solo-io/envoy-operator)| Run and manage Envoy on Kubernetes simply and securely. |
 | CloudFormation | [linki/cloudformation-operator](https://github.com/linki/cloudformation-operator)| Run and manage CloudFormation stacks. Manage AWS resources from kubernetes. |
 | ZooKeeper | [Nuance-Mobility/zookeeper-operator](https://github.com/Nuance-Mobility/zookeeper-operator) | A ZooKeeper 3.5.x Operator for Kubernetes |
+| Unifiedpush | [aerogear/ups-config-operator](https://github.com/aerogear/ups-config-operator) | Manage your Unifiedpush variants from Kubernetes / Openshift |


### PR DESCRIPTION
Add the ups operator that can be used to synchronize state between Kubernetes and the Aerogear Unifiedpush server. It allows you to create and manage mobile variants from Kubernetes.