### PR TITLE
Request to add Apache RocketMQ-Operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ If you want to start building an Operator, you should definitely look into the [
 | Redis Cluster | [AmadeusITGroup/Redis-Operator](https://github.com/AmadeusITGroup/Redis-Operator) | A Kubernetes operator for running Redis in Cluster mode |
 | Registries | [kubic-project/registries-operator](https://github.com/kubic-project/registries-operator) | A Kubernetes operator for managing images registries |
 | RethinkDB | [jmckind/rethinkdb-operator](https://github.com/jmckind/rethinkdb-operator) | RethinkDB is a free and open-source, distributed document-oriented database. This is a Kubernetes operator to manage RethinkDB instances. |
-| RocketMQ | [huanwei/rocketmq-operator](https://github.com/huanwei/rocketmq-operator) | Create, operate and scale self-healing Rocketmq clusters on Kubernetes. |
+| RocketMQ #1 | [huanwei/rocketmq-operator](https://github.com/huanwei/rocketmq-operator) | Create, operate and scale self-healing Rocketmq clusters on Kubernetes. |
+| RocketMQ #2 | [apache/rocketmq-operator](https://github.com/apache/rocketmq-operator) | RocketMQ Operator is to manage RocketMQ service instances deployed on Kubernetes. |
 | Rook | [rook/rook](https://github.com/rook/rook/tree/master/cluster/examples/kubernetes) |  File, Block, and Object Storage Services for your Cloud-Native Environment |
 | Secreter | [amaizfinance/secreter](https://github.com/amaizfinance/secreter) | Kubernetes operator and CLI tool for encrypting Kubernetes secrets and declarative secret management. |
 | Service level | [slok/service-level-operator](https://github.com/slok/service-level-operator) | Manage application's SLI and SLO's easily with the application lifecycle inside a Kubernetes cluster. |


### PR DESCRIPTION
Apache RocketMQ-Operator is to manage RocketMQ service instances deployed on the Kubernetes cluster, including RocketMQ cluster deployment, smooth scaling, topic transfer, etc.  

cc @madorn