### PR TITLE
Updates kopf operator git repository URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ If you want to start building an Operator, you should definitely look into the [
 | KMS Vault | [patoarvizu/kms-vault-operator](https://github.com/patoarvizu/kms-vault-operator) | Operator for managing [KMS](https://aws.amazon.com/kms/)-encrypted secrets and write them to [Hashicorp Vault](https://www.vaultproject.io/). |
 | Konfigurator | [stakater/konfigurator](https://github.com/stakater/konfigurator) | Dynamically generates and manages app configuration based on kubernetes resources |
 | Kong | [upmc-enterprises/kong-operator](https://github.com/upmc-enterprises/kong-operator) | Manages Kong clusters on Kubernetes (no longer actively maintained)|
-| Kopf | [kopf/operator](https://github.com/zalando-incubator/kopf) | A Python framework to write Kubernetes operators in just few lines of code.  |
+| Kopf | [kopf/operator](https://github.com/nolar/kopf) | A Python framework to write Kubernetes operators in just few lines of code.  |
 | KubeDB | [kubedb/operator](https://github.com/kubedb/operator) | KubeDB provides you with many familiar database engines to choose from, including PostgreSQL, MySQL, MongoDB, Elasticsearch, Redis, Memcached, and Percona XtraDB |
 | KubeVirt | [kubevirt/kubevirt](https://github.com/kubevirt/kubevirt) | Kubernetes Virtualization Operator with API and runtime in order to define and manage virtual machines. |
 | KUDO | [kudobuilder/kudo](https://github.com/kudobuilder/kudo) | The Kubernetes Universal Declarative Operator, a toolkit for building Kubernetes Operators declaratively using YAML. |


### PR DESCRIPTION
As it says on the Kopf page:

This repository is suspended and not maintained.

It is kept in place for historic reference, so that all links remain valid, and the issues' & PRs' discussions are preserved for debugging & investigations.

Kopf's development currently happens here:

https://github.com/nolar/kopf
Please send new issues and pull requests there.